### PR TITLE
Fix react @component parsing

### DIFF
--- a/component.js
+++ b/component.js
@@ -55,7 +55,7 @@ var parseReact = function (filePath, doclet) {
   var src = fs.readFileSync(filePath, 'UTF-8')
   var docGen
   try {
-    docGen = reactDocs.parse(src)
+        docGen = reactDocs.parse(src, null, null, { filename: '' })
   } catch (error) {
     if (error.message === 'No suitable component definition found.') {
       return {

--- a/component.js
+++ b/component.js
@@ -55,7 +55,7 @@ var parseReact = function (filePath, doclet) {
   var src = fs.readFileSync(filePath, 'UTF-8')
   var docGen
   try {
-        docGen = reactDocs.parse(src, null, null, { filename: '' })
+    docGen = reactDocs.parse(src, null, null, { filename: '' })
   } catch (error) {
     if (error.message === 'No suitable component definition found.') {
       return {


### PR DESCRIPTION
When running on a React component with the `better-docs/component` plugin enabled, this error shows up:

````
C:\<project_path>\node_modules\better-docs\component.js:68
      throw error
      ^

ConfigError: [BABEL] unknown file: Preset /* your preset */ requires a filename to be set when babel is called directly,
```
babel.transformSync(code, { filename: 'file.ts', presets: [/* your preset */] });
```
See https://babeljs.io/docs/en/options#filename for more information.
````

It appeared to be caused by the call to `reactDocs.parse()` in [component.js:58](https://github.com/SoftwareBrothers/better-docs/blob/419d4f6aef54591d54dfef034d9d705fe72dd304/component.js#L58).

By passing an empty filename argument (since it is not used anyway), the error stops being thrown and the doc builds fine.
